### PR TITLE
feat: Add custom slash commands support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 ### 💬 Smart Interactions
 - **@mentions**: Reference workspace problems and terminal output
 - **Slash Commands**: Quick access to Claude's powerful features
+- **Custom Commands**: Create your own project and user slash commands
 - **Markdown Support**: Rich formatting with syntax highlighting
 - **Code Actions**: Copy code blocks with one click
 
@@ -109,10 +110,11 @@ code --install-extension claude-code-extension-0.0.1.vsix
 ### 🔧 Advanced Features
 - **@mentions**: Type @ to reference problems or terminal output
 - **Slash Commands**: Type / to see available commands
+- **Custom Commands**: Create your own project-specific (`/project:command`) and personal (`/user:command`) slash commands
 - **Clear Chat**: Click the clear button to start fresh
 - **Restart Claude**: Use the restart button if needed
 
-See our [documentation](https://github.com/codeflow-studio/claude-code-chat/tree/main/docs) for detailed guides.
+See our [documentation](https://github.com/codeflow-studio/claude-code-chat/tree/main/docs) for detailed guides, including [how to create custom slash commands](docs/custom-slash-commands.md).
 
 ## Development
 

--- a/docs/custom-slash-commands.md
+++ b/docs/custom-slash-commands.md
@@ -1,0 +1,95 @@
+# Custom Slash Commands
+
+Claude Code VSCode Extension supports custom slash commands for quick access to frequently used prompts or operations.
+
+## Types of Custom Commands
+
+### Project Commands
+
+Project commands are specific to your project and accessible to anyone working with the project repository.
+
+- **Location**: `.claude/commands/` directory in your project
+- **Format**: Markdown files (`.md` extension)
+- **Usage**: `/project:command-name [arguments]`
+
+### User Commands
+
+User commands are personal commands that work across all projects on your machine.
+
+- **Location**: `~/.claude/commands/` directory in your home folder
+- **Format**: Markdown files (`.md` extension)
+- **Usage**: `/user:command-name [arguments]`
+
+## How It Works
+
+The VSCode extension provides **autocomplete suggestions** for your custom commands, making them easy to discover and use.
+
+When you type `/`, the extension scans for custom commands and displays them alongside built-in commands.
+
+When you select and execute a custom command, it's sent directly to Claude Code CLI which processes the command - the VSCode extension simply provides the suggestions.
+
+## Creating Custom Commands
+
+1. Create the appropriate directory:
+   - Project commands: `mkdir -p .claude/commands` (in your project root)
+   - User commands: `mkdir -p ~/.claude/commands` (in your home directory)
+
+2. Create a Markdown file with your command content:
+   - The filename (without extension) becomes the command name
+   - The content of the file is the prompt that Claude Code CLI will read
+   - Example: `.claude/commands/optimize.md` creates the command `/project:optimize`
+
+3. For commands that accept arguments, use the `$ARGUMENTS` placeholder in your command content.
+   - Example: If your command file contains `Find and fix issue #$ARGUMENTS`, calling `/project:fix-issue 123` will replace `$ARGUMENTS` with `123`
+
+## Examples
+
+### Project Command Example
+
+1. Create a file `.claude/commands/optimize.md` with the content:
+
+```markdown
+# Optimize Code
+
+Please optimize the following code for performance and readability:
+
+$ARGUMENTS
+
+Focus on:
+- Reducing time complexity
+- Improving memory usage
+- Making the code more readable
+- Adding appropriate comments
+```
+
+2. Use it in the Claude VSCode extension by typing `/project:optimize` followed by your code.
+
+### User Command Example
+
+1. Create a file `~/.claude/commands/ios-developer.md` with the content:
+
+```markdown
+# iOS Developer Mode
+
+I want you to act as an experienced iOS developer with deep knowledge of Swift, UIKit, and SwiftUI. Please help me with the following:
+
+$ARGUMENTS
+
+Focus on Swift best practices and modern iOS development patterns.
+```
+
+2. Use it by typing `/user:ios-developer` followed by your question or code.
+
+## Updating Commands
+
+The extension monitors your command directories and automatically refreshes the command list when you:
+
+1. Create, modify, or delete command files in the `.claude/commands/` or `~/.claude/commands/` directories
+2. Commands will be visible in the slash command autocomplete menu the next time you type `/`
+
+## Tips
+
+- The first line of the command file can be used as a description (if it starts with `#`)
+- Commands can include any markdown formatting
+- User commands work across all projects, making them ideal for personal workflows
+- Project commands are great for standardizing prompts across your team

--- a/media/input.js
+++ b/media/input.js
@@ -63,8 +63,8 @@
     { command: '/vim', description: 'Enter vim mode for alternating insert and command modes', icon: '📝' },
   ];
   
-  // Initialize with built-in commands, custom commands will be added
-  const ALL_SLASH_COMMANDS = [...BUILT_IN_SLASH_COMMANDS];
+  // Initialize ALL_SLASH_COMMANDS as a new array
+  let ALL_SLASH_COMMANDS = [...BUILT_IN_SLASH_COMMANDS];
   
   // Custom command storage
   let CUSTOM_SLASH_COMMANDS = [];
@@ -72,8 +72,8 @@
   // Function to filter slash commands based on query
   function filterSlashCommands(query) {
     const searchTerm = query.toLowerCase();
-    const combinedCommands = [...BUILT_IN_SLASH_COMMANDS, ...CUSTOM_SLASH_COMMANDS];
-    return combinedCommands.filter(cmd => 
+    // Use ALL_SLASH_COMMANDS which already contains both built-in and custom commands
+    return ALL_SLASH_COMMANDS.filter(cmd => 
       cmd.command.toLowerCase().includes(searchTerm) ||
       cmd.description.toLowerCase().includes(searchTerm)
     );
@@ -82,9 +82,24 @@
   // Function to add custom commands to the list
   function updateCustomCommands(customCommands) {
     if (Array.isArray(customCommands) && customCommands.length > 0) {
-      CUSTOM_SLASH_COMMANDS = customCommands;
-      ALL_SLASH_COMMANDS.length = BUILT_IN_SLASH_COMMANDS.length; // Reset to just the built-in commands
-      ALL_SLASH_COMMANDS.push(...CUSTOM_SLASH_COMMANDS); // Add custom commands
+      console.log('Updating custom commands:', customCommands);
+      // Clear any previous custom commands
+      CUSTOM_SLASH_COMMANDS = [];
+      // Add new custom commands, ensuring no duplicates by checking if command already exists
+      customCommands.forEach(cmd => {
+        // Check if we already have this command (prevents duplicates)
+        const exists = CUSTOM_SLASH_COMMANDS.some(existing => existing.command === cmd.command);
+        if (!exists) {
+          CUSTOM_SLASH_COMMANDS.push(cmd);
+        }
+      });
+      
+      // Reset ALL_SLASH_COMMANDS to just built-in commands
+      ALL_SLASH_COMMANDS = [...BUILT_IN_SLASH_COMMANDS];
+      // Add unique custom commands
+      ALL_SLASH_COMMANDS.push(...CUSTOM_SLASH_COMMANDS);
+      
+      console.log('Updated ALL_SLASH_COMMANDS:', ALL_SLASH_COMMANDS);
     }
   }
   
@@ -665,12 +680,10 @@
       const currentLine = lines[lines.length - 1];
       const queryAfterSlash = currentLine.substring(1);
       
-      // Filter slash commands based on query
-      // Use combined list of built-in and custom commands
-      const combinedCommands = [...BUILT_IN_SLASH_COMMANDS, ...CUSTOM_SLASH_COMMANDS];
-      
+      // Filter slash commands based on query 
       if (queryAfterSlash.length === 0) {
-        slashCommands = combinedCommands;
+        // Use ALL_SLASH_COMMANDS which already contains both built-in and custom commands
+        slashCommands = ALL_SLASH_COMMANDS;
       } else {
         slashCommands = filterSlashCommands(queryAfterSlash);
       }
@@ -1014,6 +1027,7 @@
       case 'customCommandsUpdated':
         // Handle custom commands update from the extension
         if (message.customCommands) {
+          console.log('Received custom commands from extension:', message.customCommands);
           updateCustomCommands(message.customCommands);
         }
         break;

--- a/media/input.js
+++ b/media/input.js
@@ -44,7 +44,7 @@
   ];
   
   // Slash commands
-  const ALL_SLASH_COMMANDS = [
+  const BUILT_IN_SLASH_COMMANDS = [
     { command: '/bug', description: 'Report bugs (sends conversation to Anthropic)', icon: '🐛' },
     { command: '/clear', description: 'Clear conversation history', icon: '🗑️' },
     { command: '/compact', description: 'Compact conversation with optional focus instructions', icon: '📦' },
@@ -62,14 +62,30 @@
     { command: '/terminal-setup', description: 'Install Shift+Enter key binding for newlines', icon: '⌨️' },
     { command: '/vim', description: 'Enter vim mode for alternating insert and command modes', icon: '📝' },
   ];
+  
+  // Initialize with built-in commands, custom commands will be added
+  const ALL_SLASH_COMMANDS = [...BUILT_IN_SLASH_COMMANDS];
+  
+  // Custom command storage
+  let CUSTOM_SLASH_COMMANDS = [];
 
   // Function to filter slash commands based on query
   function filterSlashCommands(query) {
     const searchTerm = query.toLowerCase();
-    return ALL_SLASH_COMMANDS.filter(cmd => 
+    const combinedCommands = [...BUILT_IN_SLASH_COMMANDS, ...CUSTOM_SLASH_COMMANDS];
+    return combinedCommands.filter(cmd => 
       cmd.command.toLowerCase().includes(searchTerm) ||
       cmd.description.toLowerCase().includes(searchTerm)
     );
+  }
+  
+  // Function to add custom commands to the list
+  function updateCustomCommands(customCommands) {
+    if (Array.isArray(customCommands) && customCommands.length > 0) {
+      CUSTOM_SLASH_COMMANDS = customCommands;
+      ALL_SLASH_COMMANDS.length = BUILT_IN_SLASH_COMMANDS.length; // Reset to just the built-in commands
+      ALL_SLASH_COMMANDS.push(...CUSTOM_SLASH_COMMANDS); // Add custom commands
+    }
   }
   
   // Function to check if slash command menu should be shown
@@ -650,8 +666,11 @@
       const queryAfterSlash = currentLine.substring(1);
       
       // Filter slash commands based on query
+      // Use combined list of built-in and custom commands
+      const combinedCommands = [...BUILT_IN_SLASH_COMMANDS, ...CUSTOM_SLASH_COMMANDS];
+      
       if (queryAfterSlash.length === 0) {
-        slashCommands = ALL_SLASH_COMMANDS;
+        slashCommands = combinedCommands;
       } else {
         slashCommands = filterSlashCommands(queryAfterSlash);
       }
@@ -989,6 +1008,13 @@
             });
           });
           updateImagePreview();
+        }
+        break;
+        
+      case 'customCommandsUpdated':
+        // Handle custom commands update from the extension
+        if (message.customCommands) {
+          updateCustomCommands(message.customCommands);
         }
         break;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ClaudeTerminalInputProvider } from './ui/claudeTerminalInputProvider';
 import { customCommandService } from './service/customCommandService';
 
@@ -54,13 +55,29 @@ export function activate(context: vscode.ExtensionContext) {
     console.error('Error scanning custom commands:', err);
   });
   
-  // Watch for changes to custom command files
+  // Watch for changes to custom command files (project-specific)
   const projectWatcher = vscode.workspace.createFileSystemWatcher('**/.claude/commands/*.md');
   
   // When files are created, changed or deleted, rescan custom commands
   projectWatcher.onDidCreate(() => customCommandService.scanCustomCommands());
   projectWatcher.onDidChange(() => customCommandService.scanCustomCommands());
   projectWatcher.onDidDelete(() => customCommandService.scanCustomCommands());
+  
+  // Watch for changes to user-specific custom command files
+  let userCommandsPath = '';
+  try {
+    const homeDir = process.env.HOME || process.env.USERPROFILE;
+    if (homeDir) {
+      userCommandsPath = path.join(homeDir, '.claude', 'commands', '*.md').replace(/\\/g, '/');
+      const userWatcher = vscode.workspace.createFileSystemWatcher(userCommandsPath);
+      userWatcher.onDidCreate(() => customCommandService.scanCustomCommands());
+      userWatcher.onDidChange(() => customCommandService.scanCustomCommands());
+      userWatcher.onDidDelete(() => customCommandService.scanCustomCommands());
+      context.subscriptions.push(userWatcher);
+    }
+  } catch (err) {
+    console.error('Error setting up user commands watcher:', err);
+  }
   
   // Register the watcher for disposal when extension is deactivated
   context.subscriptions.push(projectWatcher);

--- a/src/service/customCommandService.ts
+++ b/src/service/customCommandService.ts
@@ -1,0 +1,188 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SlashCommand } from '../utils/slash-commands';
+
+export interface CustomCommand {
+  name: string;        // Command name without prefix
+  file: string;        // Path to the command file
+  type: 'project' | 'user'; // Whether this is a project or user command
+  description?: string; // Optional description (first line of the file)
+}
+
+export class CustomCommandService {
+  private projectCommands: CustomCommand[] = [];
+  private userCommands: CustomCommand[] = [];
+
+  constructor() {}
+
+  /**
+   * Scans for custom slash commands in both project and user directories
+   * @returns Promise that resolves when scanning is complete
+   */
+  public async scanCustomCommands(): Promise<void> {
+    // Reset the command arrays
+    this.projectCommands = [];
+    this.userCommands = [];
+
+    // Scan project commands
+    await this.scanProjectCommands();
+    
+    // Scan user commands
+    await this.scanUserCommands();
+  }
+
+  /**
+   * Gets all custom commands as SlashCommand objects
+   * @returns Array of SlashCommand objects
+   */
+  public getCustomCommands(): SlashCommand[] {
+    const commands: SlashCommand[] = [];
+
+    // Add project commands
+    for (const cmd of this.projectCommands) {
+      commands.push({
+        command: `/project:${cmd.name}`,
+        description: cmd.description || `Project command: ${cmd.name}`,
+        icon: '📄', // Document icon for project commands
+        isCustom: true
+      });
+    }
+
+    // Add user commands
+    for (const cmd of this.userCommands) {
+      commands.push({
+        command: `/user:${cmd.name}`,
+        description: cmd.description || `User command: ${cmd.name}`,
+        icon: '👤', // User icon for user commands
+        isCustom: true
+      });
+    }
+
+    return commands;
+  }
+
+  /**
+   * Scans for project commands in the .claude/commands directory
+   */
+  private async scanProjectCommands(): Promise<void> {
+    // Get workspace folders
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+      return;
+    }
+
+    // Use the first workspace folder
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    const commandsDir = path.join(workspaceRoot, '.claude', 'commands');
+
+    try {
+      // Check if the commands directory exists
+      const stats = await fs.promises.stat(commandsDir);
+      if (!stats.isDirectory()) {
+        return;
+      }
+
+      // Read the directory
+      const files = await fs.promises.readdir(commandsDir);
+      
+      // Process each markdown file
+      for (const file of files) {
+        if (path.extname(file).toLowerCase() === '.md') {
+          const filePath = path.join(commandsDir, file);
+          const name = path.basename(file, '.md');
+          
+          // Read the first line for description
+          try {
+            const content = await fs.promises.readFile(filePath, 'utf-8');
+            const firstLine = content.split('\n')[0].trim();
+            const description = firstLine.startsWith('#') 
+              ? firstLine.substring(1).trim() 
+              : firstLine;
+
+            this.projectCommands.push({
+              name,
+              file: filePath,
+              type: 'project',
+              description: description || undefined
+            });
+          } catch (err) {
+            console.error(`Error reading project command file ${filePath}:`, err);
+            // Add without description if we couldn't read it
+            this.projectCommands.push({
+              name,
+              file: filePath,
+              type: 'project'
+            });
+          }
+        }
+      }
+    } catch (err) {
+      // Directory doesn't exist or can't be read, which is fine
+      console.log('No project commands directory found or error reading it:', err);
+    }
+  }
+
+  /**
+   * Scans for user commands in the ~/.claude/commands directory
+   */
+  private async scanUserCommands(): Promise<void> {
+    try {
+      // Get user home directory
+      const homeDir = process.env.HOME || process.env.USERPROFILE;
+      if (!homeDir) {
+        console.error('Could not determine user home directory');
+        return;
+      }
+
+      const commandsDir = path.join(homeDir, '.claude', 'commands');
+
+      // Check if the directory exists
+      const stats = await fs.promises.stat(commandsDir);
+      if (!stats.isDirectory()) {
+        return;
+      }
+
+      // Read the directory
+      const files = await fs.promises.readdir(commandsDir);
+      
+      // Process each markdown file
+      for (const file of files) {
+        if (path.extname(file).toLowerCase() === '.md') {
+          const filePath = path.join(commandsDir, file);
+          const name = path.basename(file, '.md');
+          
+          // Read the first line for description
+          try {
+            const content = await fs.promises.readFile(filePath, 'utf-8');
+            const firstLine = content.split('\n')[0].trim();
+            const description = firstLine.startsWith('#') 
+              ? firstLine.substring(1).trim() 
+              : firstLine;
+
+            this.userCommands.push({
+              name,
+              file: filePath,
+              type: 'user',
+              description: description || undefined
+            });
+          } catch (err) {
+            console.error(`Error reading user command file ${filePath}:`, err);
+            // Add without description if we couldn't read it
+            this.userCommands.push({
+              name,
+              file: filePath,
+              type: 'user'
+            });
+          }
+        }
+      }
+    } catch (err) {
+      // Directory doesn't exist or can't be read, which is fine
+      console.log('No user commands directory found or error reading it:', err);
+    }
+  }
+}
+
+// Create a singleton instance
+export const customCommandService = new CustomCommandService();

--- a/src/ui/claudeTerminalInputProvider.ts
+++ b/src/ui/claudeTerminalInputProvider.ts
@@ -546,9 +546,23 @@ export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {
       
       // Send the custom commands to the webview
       if (this._view) {
+        const customCommands = customCommandService.getCustomCommands();
+        
+        console.log('Sending custom commands to webview:', customCommands);
+        
+        // Ensure we're not sending duplicates
+        const commandMap = new Map();
+        customCommands.forEach(cmd => {
+          // Use command name as key to prevent duplicates
+          commandMap.set(cmd.command, cmd);
+        });
+        
+        // Convert back to array
+        const uniqueCommands = Array.from(commandMap.values());
+        
         this._view.webview.postMessage({
           command: 'customCommandsUpdated',
-          customCommands: customCommandService.getCustomCommands()
+          customCommands: uniqueCommands
         });
       }
     } catch (error) {

--- a/src/ui/claudeTerminalInputProvider.ts
+++ b/src/ui/claudeTerminalInputProvider.ts
@@ -3,7 +3,6 @@ import { getNonce } from "../utils";
 import { searchFiles, getGitCommits } from "../fileSystem";
 import { ImageManager } from "../service/imageManager";
 import { fileServiceClient } from "../api/FileService";
-import { isCustomCommand, processCustomCommand } from "../utils/slash-commands";
 import { customCommandService } from "../service/customCommandService";
 
 export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {

--- a/src/ui/components/SlashCommandSuggestions.ts
+++ b/src/ui/components/SlashCommandSuggestions.ts
@@ -1,8 +1,10 @@
-import { SlashCommand, SLASH_COMMANDS, filterSlashCommands } from '../../utils/slash-commands';
+import { SlashCommand, BUILT_IN_SLASH_COMMANDS, filterSlashCommands } from '../../utils/slash-commands';
 
 export class SlashCommandSuggestions {
   private container: HTMLDivElement;
   private commands: SlashCommand[] = [];
+  private allCommands: SlashCommand[] = [...BUILT_IN_SLASH_COMMANDS];
+  private customCommandsLoaded: boolean = false;
   private selectedIndex: number = -1;
   private onSelectCallback?: (command: string) => void;
   private onDismissCallback?: () => void;
@@ -28,7 +30,7 @@ export class SlashCommandSuggestions {
     this.onDismissCallback = onDismiss;
     
     // Filter commands based on search term
-    this.commands = searchTerm ? filterSlashCommands(searchTerm) : SLASH_COMMANDS;
+    this.commands = searchTerm ? filterSlashCommands(searchTerm, this.allCommands) : this.allCommands;
     
     if (this.commands.length === 0) {
       this.hide();
@@ -161,5 +163,21 @@ export class SlashCommandSuggestions {
       this.container.style.right = '0';
       this.container.style.maxHeight = '300px';
     }
+  }
+  
+  /**
+   * Update the list of custom commands
+   * @param customCommands Array of custom slash commands
+   */
+  public updateCustomCommands(customCommands: SlashCommand[]): void {
+    // Start with built-in commands
+    this.allCommands = [...BUILT_IN_SLASH_COMMANDS];
+    
+    // Add custom commands
+    if (customCommands && customCommands.length > 0) {
+      this.allCommands = [...this.allCommands, ...customCommands];
+    }
+    
+    this.customCommandsLoaded = true;
   }
 }

--- a/src/utils/slash-commands.ts
+++ b/src/utils/slash-commands.ts
@@ -1,11 +1,14 @@
+import { customCommandService } from '../service/customCommandService';
+
 export interface SlashCommand {
   command: string;
   description: string;
   icon?: string;
   shortcut?: string;
+  isCustom?: boolean;  // Flag to identify custom commands
 }
 
-export const SLASH_COMMANDS: SlashCommand[] = [
+export const BUILT_IN_SLASH_COMMANDS: SlashCommand[] = [
   { command: '/bug', description: 'Report bugs (sends conversation to Anthropic)', icon: '🐛' },
   { command: '/clear', description: 'Clear conversation history', icon: '🗑️' },
   { command: '/compact', description: 'Compact conversation with optional focus instructions', icon: '📦' },
@@ -24,14 +27,41 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/vim', description: 'Enter vim mode for alternating insert and command modes', icon: '📝' },
 ];
 
-export function filterSlashCommands(input: string): SlashCommand[] {
+// Keep this for backward compatibility
+export const SLASH_COMMANDS = BUILT_IN_SLASH_COMMANDS;
+
+/**
+ * Gets all available slash commands including custom ones
+ * @returns All slash commands (built-in and custom)
+ */
+export async function getAllSlashCommands(): Promise<SlashCommand[]> {
+  await customCommandService.scanCustomCommands();
+  const customCommands = customCommandService.getCustomCommands();
+  
+  // Combine built-in and custom commands
+  return [...BUILT_IN_SLASH_COMMANDS, ...customCommands];
+}
+
+/**
+ * Filter slash commands based on input
+ * @param input The search input
+ * @param commands The array of commands to filter (defaults to built-in commands)
+ * @returns Filtered slash commands
+ */
+export function filterSlashCommands(input: string, commands: SlashCommand[] = BUILT_IN_SLASH_COMMANDS): SlashCommand[] {
   const searchTerm = input.toLowerCase();
-  return SLASH_COMMANDS.filter(cmd => 
+  return commands.filter(cmd => 
     cmd.command.toLowerCase().includes(searchTerm) ||
     cmd.description.toLowerCase().includes(searchTerm)
   );
 }
 
-export function getSlashCommand(command: string): SlashCommand | undefined {
-  return SLASH_COMMANDS.find(cmd => cmd.command === command);
+/**
+ * Gets a slash command by its exact name
+ * @param command The command name to find
+ * @param commands The array of commands to search (defaults to built-in commands)
+ * @returns The found command or undefined
+ */
+export function getSlashCommand(command: string, commands: SlashCommand[] = BUILT_IN_SLASH_COMMANDS): SlashCommand | undefined {
+  return commands.find(cmd => cmd.command === command);
 }


### PR DESCRIPTION
- Add support for project-specific and user-specific slash commands
- Implement command directories in .claude/commands/ and ~/.claude/commands/
- Add documentation for creating and using custom commands
- Update README with new custom commands feature