### PR TITLE
feat: Add context menu option to add selected code to Claude input

### DIFF
--- a/media/input.js
+++ b/media/input.js
@@ -1051,6 +1051,39 @@
           updateCustomCommands(message.customCommands);
         }
         break;
+        
+      case 'addTextToInput':
+        // Handle adding text to the input field from context menu
+        if (message.text && messageInputElement) {
+          const currentValue = messageInputElement.value;
+          const cursorPosition = messageInputElement.selectionStart || messageInputElement.value.length;
+          
+          // Add space before if needed
+          const needsSpaceBefore = currentValue.length > 0 && !currentValue.endsWith(' ') && !currentValue.endsWith('\n');
+          const spaceBefore = needsSpaceBefore ? '\n\n' : '';
+          
+          // Add space after
+          const spaceAfter = '\n';
+          
+          // Insert the text at cursor position
+          const beforeCursor = currentValue.slice(0, cursorPosition);
+          const afterCursor = currentValue.slice(cursorPosition);
+          const newValue = beforeCursor + spaceBefore + message.text + spaceAfter + afterCursor;
+          
+          messageInputElement.value = newValue;
+          
+          // Set cursor position after the inserted text
+          const newCursorPosition = cursorPosition + spaceBefore.length + message.text.length + spaceAfter.length;
+          messageInputElement.setSelectionRange(newCursorPosition, newCursorPosition);
+          
+          // Update highlights and resize
+          updateHighlights();
+          autoResizeTextarea();
+          
+          // Focus the input
+          messageInputElement.focus();
+        }
+        break;
     }
   });
   

--- a/package.json
+++ b/package.json
@@ -34,10 +34,6 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onCommand:claude-code-extension.launchClaudeCodeTerminal",
-    "onView:claudeCodeInputView"
-  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -53,6 +49,10 @@
           "light": "resources/restart-light.svg",
           "dark": "resources/restart-dark.svg"
         }
+      },
+      {
+        "command": "claude-code-extension.addSelectionToInput",
+        "title": "Add to Claude Code Input"
       }
     ],
     "viewsContainers": {
@@ -85,6 +85,13 @@
           "command": "claude-code-extension.restartClaudeCode",
           "group": "navigation",
           "when": "view == claudeCodeInputView"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "claude-code-extension.addSelectionToInput",
+          "when": "editorHasSelection",
+          "group": "navigation"
         }
       ]
     },

--- a/src/ui/claudeTerminalInputProvider.ts
+++ b/src/ui/claudeTerminalInputProvider.ts
@@ -43,6 +43,19 @@ export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {
       });
     }
   }
+
+  public addTextToInput(text: string) {
+    // Send the text to the webview input field
+    if (this._view) {
+      this._view.webview.postMessage({
+        command: "addTextToInput",
+        text: text
+      });
+      
+      // Focus the input view
+      vscode.commands.executeCommand('claudeCodeInputView.focus');
+    }
+  }
   
   /**
    * Sends a command to the Claude terminal asynchronously


### PR DESCRIPTION
- Add "Add to Claude Code Input" context menu option when text is selected
- Format selected code with file path reference (@filepath) and code blocks
- Automatically focus Claude Code input panel after insertion
- Support both workspace-relative and absolute file paths
- Add proper spacing and formatting for better readability

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>