### PR TITLE
fix: Fix image attachment formatting for multiple images

### DIFF
--- a/src/service/imageManager.ts
+++ b/src/service/imageManager.ts
@@ -199,11 +199,12 @@ export class ImageManager {
     if (imageCount === 1) {
       // return `${instructions}Attached Image => '${imagePaths[0]}'`;
       instructions += `Attached Image => '${imagePaths[0]}'`;
+    } else {
+      const imageList = imagePaths
+        .map((path, index) => `Attached Image ${index + 1} => '${path}'`)
+        .join("\n");
+      instructions += imageList;
     }
-    const imageList = imagePaths
-      .map((path, index) => `Attached Image ${index + 1} => '${path}'`)
-      .join("\n");
-    instructions += imageList;
     instructions += `\n</ATTACHED_IMAGES>\n`;
     return instructions;
   }


### PR DESCRIPTION
- Fixed conditional logic in formatImagesForClaude method
- Single image case now properly formats without index numbers
- Multiple images case properly formats with index numbers
- Eliminates duplicate image listings in Claude Code input

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>