### PR TITLE
feat: Claude Code mode toggle button with custom SVG icon

### DIFF
--- a/media/input.js
+++ b/media/input.js
@@ -13,6 +13,7 @@
   const imageInputElement = document.getElementById('imageInput');
   const imagePreviewContainer = document.getElementById('imagePreviewContainer');
   const problemPreviewContainer = document.getElementById('problemPreviewContainer');
+  const modeToggleButtonElement = document.getElementById('modeToggleButton');
   
   // RegExp for detecting @ mentions
   const mentionRegex = /@((?:\/|\w+:\/\/)[^\s]+?|[a-f0-9]{7,40}\b|problems\b|git-changes\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/;
@@ -1392,6 +1393,16 @@
       // Request VSCode to open file selection dialog
       vscode.postMessage({
         command: 'selectImageFiles'
+      });
+    });
+  }
+
+  // Event listener for mode toggle button
+  if (modeToggleButtonElement) {
+    modeToggleButtonElement.addEventListener('click', () => {
+      // Send mode toggle command to extension
+      vscode.postMessage({
+        command: 'toggleMode'
       });
     });
   }

--- a/media/styles.css
+++ b/media/styles.css
@@ -1223,7 +1223,8 @@ button svg {
 }
 
 .input-bottom-actions .context-button,
-.input-bottom-actions .image-button {
+.input-bottom-actions .image-button,
+.input-bottom-actions .mode-toggle-button {
   width: 28px;
   height: 28px;
   padding: 6px;
@@ -1241,7 +1242,8 @@ button svg {
 }
 
 .input-bottom-actions .context-button:hover,
-.input-bottom-actions .image-button:hover {
+.input-bottom-actions .image-button:hover,
+.input-bottom-actions .mode-toggle-button:hover {
   opacity: 1;
   background-color: var(--vscode-list-hoverBackground);
 }
@@ -1249,6 +1251,16 @@ button svg {
 .input-bottom-actions .context-button {
   font-weight: bold;
   font-size: 16px;
+}
+
+.input-bottom-actions .mode-toggle-button {
+  font-size: 18px;
+  font-weight: normal;
+}
+
+.input-bottom-actions .mode-toggle-button img {
+  width: 16px;
+  height: 16px;
 }
 
 .input-bottom-actions .image-button svg,
@@ -1259,11 +1271,14 @@ button svg {
 
 /* Apply filter to make the image match the text color */
 .vscode-dark .input-bottom-actions .image-button img,
-.vscode-high-contrast .input-bottom-actions .image-button img {
+.vscode-high-contrast .input-bottom-actions .image-button img,
+.vscode-dark .input-bottom-actions .mode-toggle-button img,
+.vscode-high-contrast .input-bottom-actions .mode-toggle-button img {
   filter: brightness(0) saturate(100%) invert(100%);
 }
 
-.vscode-light .input-bottom-actions .image-button img {
+.vscode-light .input-bottom-actions .image-button img,
+.vscode-light .input-bottom-actions .mode-toggle-button img {
   filter: brightness(0) saturate(100%);
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-extension",
   "displayName": "Claude Code Assistant for VSCode",
   "description": "Unofficial integration of Anthropic's Claude Code AI assistant into VSCode",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "publisher": "codeflow-studio",
   "icon": "resources/claude-icon.png",
   "repository": {
@@ -53,6 +53,10 @@
       {
         "command": "claude-code-extension.addSelectionToInput",
         "title": "Add to Claude Code Input"
+      },
+      {
+        "command": "claude-code-extension.toggleMode",
+        "title": "Claude Code: Toggle Mode (Shift+Tab)"
       }
     ],
     "viewsContainers": {

--- a/resources/mode-toggle.svg
+++ b/resources/mode-toggle.svg
@@ -1,0 +1,16 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Mode toggle icon representing cycling between states -->
+  <g stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Circular arrows showing cycle/toggle -->
+    <path d="M7 3.5C4.5 4.5 3 7 3 10c0 3.5 2.5 6.5 6 7" opacity="0.7"/>
+    <path d="M13 16.5C15.5 15.5 17 13 17 10c0-3.5-2.5-6.5-6-7" opacity="0.7"/>
+    
+    <!-- Arrow heads -->
+    <path d="M6 1.5L7 3.5L5.5 4"/>
+    <path d="M14 18.5L13 16.5L14.5 16"/>
+    
+    <!-- Center dots representing different modes -->
+    <circle cx="8" cy="10" r="1.5" fill="currentColor" opacity="0.8"/>
+    <circle cx="12" cy="10" r="1.5" fill="currentColor" opacity="0.4"/>
+  </g>
+</svg>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -422,6 +422,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(addSelectionToInputCommand);
 
+  // Register command to toggle Claude Code mode
+  const toggleModeCommand = vscode.commands.registerCommand('claude-code-extension.toggleMode', async () => {
+    // Check if provider is initialized
+    if (!claudeTerminalInputProvider) {
+      vscode.window.showErrorMessage('Claude terminal input provider not initialized');
+      return;
+    }
+
+    // Call the public toggle mode method
+    await claudeTerminalInputProvider.toggleMode();
+  });
+
+  context.subscriptions.push(toggleModeCommand);
+
   // Register Claude Code Action Provider for Quick Fix menu
   const claudeCodeActionProvider = new ClaudeCodeActionProvider(claudeTerminalInputProvider);
   context.subscriptions.push(

--- a/src/ui/claudeTerminalInputProvider.ts
+++ b/src/ui/claudeTerminalInputProvider.ts
@@ -202,6 +202,10 @@ export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {
           case "launchClaudeHistory":
             this._handleLaunchClaudeHistory();
             return;
+            
+          case "toggleMode":
+            this._handleModeToggle();
+            return;
         }
       },
       undefined,
@@ -1023,6 +1027,41 @@ export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  /**
+   * Public method to toggle Claude Code mode (exposed for command palette access)
+   */
+  public async toggleMode(): Promise<void> {
+    await this._handleModeToggle();
+  }
+
+  /**
+   * Handles mode toggle by sending Shift+Tab to Claude Code terminal
+   */
+  private async _handleModeToggle() {
+    try {
+      console.log('Toggling Claude Code mode (Shift+Tab)');
+      
+      // Check if terminal is available
+      if (this._isTerminalClosed || !this._terminal) {
+        vscode.window.showWarningMessage('Claude Code terminal is not active. Please start Claude Code first.');
+        return;
+      }
+      
+      // Show the terminal in the background (preserves focus)
+      this._terminal?.show(true);
+      
+      // Send Shift+Tab key sequence to toggle mode
+      // \x1b[Z is the escape sequence for Shift+Tab
+      this._terminal?.sendText('\x1b[Z', false);
+      
+      console.log('Mode toggle command sent to Claude Code terminal');
+      
+    } catch (error) {
+      console.error('Error toggling Claude mode:', error);
+      vscode.window.showErrorMessage(`Failed to toggle Claude mode: ${error}`);
+    }
+  }
+
   private _getHtmlForWebview(webview: vscode.Webview) {
     // Generate nonce for script security
     const nonce = getNonce();
@@ -1042,6 +1081,9 @@ export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {
     );
     const imageIconPath = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, "resources", "image-svgrepo-com.svg")
+    );
+    const modeToggleIconPath = webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, "resources", "mode-toggle.svg")
     );
     const codiconsCss = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, "media", "codicon.css")
@@ -1155,6 +1197,9 @@ export class ClaudeTerminalInputProvider implements vscode.WebviewViewProvider {
               </button>
               <button id="imageButton" title="Attach image" class="image-button">
                 <img src="${imageIconPath}" width="20" height="20" alt="Attach Image" />
+              </button>
+              <button id="modeToggleButton" title="Toggle Claude Mode (Shift+Tab)" class="mode-toggle-button">
+                <img src="${modeToggleIconPath}" width="16" height="16" alt="Toggle Mode" />
               </button>
             </div>
             <div id="contextMenuContainer" class="context-menu-container" style="display: none;"></div>


### PR DESCRIPTION
## Summary

- Add mode cycling button next to image button for easy access to Claude Code's Shift+Tab functionality
- Toggle between Claude Code operating modes (auto-accept edits, plan mode, etc.) directly from VSCode
- Beautiful custom SVG icon with circular arrows representing mode switching
- Full theme integration with automatic color adaptation

## Features Added

### 🎯 **Mode Toggle Button**
- **Location**: Right of image button in input actions bar
- **Icon**: Custom SVG with circular arrows and mode dots
- **Function**: Sends Shift+Tab to Claude Code terminal to cycle modes
- **Tooltip**: "Toggle Claude Mode (Shift+Tab)"

### 🎨 **Custom SVG Icon**
- Professional circular arrow design representing cycling/switching
- Two center dots showing different modes (active/inactive)
- Theme-adaptive colors (automatic light/dark mode support)
- Scalable vector graphics for crisp display at any size

### ⌨️ **Command Palette Integration**
- Command: "Claude Code: Toggle Mode (Shift+Tab)"
- Accessible via Cmd/Ctrl+Shift+P
- Same functionality as UI button

### 🛡️ **Error Handling**
- Validates Claude Code terminal is active before sending commands
- User-friendly warning messages for inactive terminals
- Proper error logging for debugging

## Technical Implementation

### Frontend Changes
- Added `modeToggleButton` element to HTML template
- JavaScript event handler for button clicks
- CSS styling consistent with existing buttons

### Backend Changes  
- `_handleModeToggle()` method sends `\x1b[Z` (Shift+Tab) to terminal
- Public `toggleMode()` API for command palette access
- Message handler for webview communication

### Design Integration
- CSS filters for theme color adaptation
- Consistent sizing and spacing with existing buttons
- Hover effects and opacity transitions

## How to Use

1. **Via UI Button**: Click the cycle icon (🔄) next to the image button
2. **Via Command Palette**: Search for "Claude Code: Toggle Mode"
3. **Requirements**: Claude Code must be running in terminal

## Screenshots

Before: `@ [image]`
After: `@ [image] [🔄]`

## Testing

- ✅ Button appears correctly in UI
- ✅ Sends Shift+Tab to Claude Code terminal
- ✅ Theme colors adapt properly
- ✅ Command palette integration works
- ✅ Error handling for inactive terminals
- ✅ Consistent styling with existing buttons

This enhancement provides seamless access to Claude Code's mode cycling feature directly from the VSCode interface, eliminating the need to manually press Shift+Tab in the terminal.

🤖 Generated with Claude Code